### PR TITLE
fix formatting of preload command examples

### DIFF
--- a/pages/reference/cli.md
+++ b/pages/reference/cli.md
@@ -1203,8 +1203,9 @@ Use this command to preload an application to a local disk image (or
 Edison zip archive) with a built release from Resin.io.
 
 Examples:
-  $ resin preload resin.img --app 1234 --commit e1f2592fc6ee949e68756d4f4a48e49bff8d72a0 --splash-image some-image.png
-  $ resin preload resin.img
+
+	$ resin preload resin.img --app 1234 --commit e1f2592fc6ee949e68756d4f4a48e49bff8d72a0 --splash-image some-image.png
+	$ resin preload resin.img
 
 ### Options
 


### PR DESCRIPTION
missing blank line between `Examples:` and the actual examples for the preload command